### PR TITLE
167 investigate arm64 builds for macos

### DIFF
--- a/.github/workflows/build_and_publish_to_test_pypi.yml
+++ b/.github/workflows/build_and_publish_to_test_pypi.yml
@@ -42,6 +42,9 @@ jobs:
       - name: 'Install MacPorts'
         if: runner.os == 'macOS'
         uses: melusina-org/setup-macports@v1
+
+      - name: 'Install MacPorts Packages'
+        if: runner.os == 'macOS'
         run: |
           port clean net-snmp openssl;
           port install net-snmp openssl;

--- a/.github/workflows/build_and_publish_to_test_pypi.yml
+++ b/.github/workflows/build_and_publish_to_test_pypi.yml
@@ -38,21 +38,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
-  
-      - name: 'Install MacPorts'
-        if: runner.os == 'macOS'
-        run: |
-          mkdir -p $HOME/opt/mports
-          cd $HOME/opt/mports
-          wget https://github.com/macports/macports-base/releases/download/v2.10.1/MacPorts-2.10.1.tar.gz
-          tar -xzvf MacPorts-2.10.1.tar.gz
-          cd $HOME/opt/mports/MacPorts-2.10.1
-          ./configure --prefix=$HOME/opt/local --with-install-user=`id -un` --with-install-group=`id -gn`
-          make
-          make install
-          make distclean
-          export PATH=$HOME/opt/local/bin:$HOME/opt/local/sbin:$PATH
-          port selfupdate
 
       - name: Install cibuildwheel
         run: |

--- a/.github/workflows/build_and_publish_to_test_pypi.yml
+++ b/.github/workflows/build_and_publish_to_test_pypi.yml
@@ -5,35 +5,34 @@ name: TestPyPI Distributions
 concurrency: build_and_publish_to_test_pypi
 on:
   push:
-    branches: [167-investigate-arm64-builds-for-macos]
+    branches: [main]
 
 jobs:
-  # check-source-changes:
-  #   runs-on: ubuntu-latest
-  #   outputs:
-  #     run_job: ${{ steps.changed-files.outputs.any_changed }}
-  #   steps:
-  #     - name: Checkout Sourcecode
-  #       uses: actions/checkout@v4
+  check-source-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      run_job: ${{ steps.changed-files.outputs.any_changed }}
+    steps:
+      - name: Checkout Sourcecode
+        uses: actions/checkout@v4
 
-  #     - name: Check for changes in setup.py/cfg
-  #       id: changed-files
-  #       uses: tj-actions/changed-files@v45.0.0
-  #       with:
-  #         files: |
-  #           setup.py
-  #           setup.cfg
+      - name: Check for changes in setup.py/cfg
+        id: changed-files
+        uses: tj-actions/changed-files@v45.0.0
+        with:
+          files: |
+            setup.py
+            setup.cfg
 
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    # needs: check-source-changes
-    # if: needs.check-source-changes.outputs.run_job == 'true'
+    needs: check-source-changes
+    if: needs.check-source-changes.outputs.run_job == 'true'
     strategy:
       matrix:
-        # os: [ubuntu-latest, macos-13, macos-14]
         # macos-13 is an intel runner, macos-14 is apple silicon
-        os: [macos-13, macos-14]
+        os: [ubuntu-latest, macos-13, macos-14]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build_and_publish_to_test_pypi.yml
+++ b/.github/workflows/build_and_publish_to_test_pypi.yml
@@ -44,9 +44,9 @@ jobs:
         run: |
           mkdir -p $HOME/opt/mports
           cd $HOME/opt/mports
-          wget https://github.com/macports/macports-base/releases/download/v2.9.1/MacPorts-2.9.1.tar.gz
-          tar -xzvf MacPorts-2.9.1.tar.gz
-          cd $HOME/opt/mports/MacPorts-2.9.1
+          wget https://github.com/macports/macports-base/releases/download/v2.10.1/MacPorts-2.10.1.tar.gz
+          tar -xzvf MacPorts-2.10.1.tar.gz
+          cd $HOME/opt/mports/MacPorts-2.10.1
           ./configure --prefix=$HOME/opt/local --with-install-user=`id -un` --with-install-group=`id -gn`
           make
           make install
@@ -63,7 +63,8 @@ jobs:
         with:
           linux: python -m cibuildwheel --output-dir wheelhouse --platform linux;
           
-          macos: port clean net-snmp openssl;
+          macos: export PATH=$HOME/opt/local/bin:$HOME/opt/local/sbin:$PATH;
+                 port clean net-snmp openssl;
                  port install net-snmp openssl;
                  python -m cibuildwheel --output-dir wheelhouse --platform macos;
 

--- a/.github/workflows/build_and_publish_to_test_pypi.yml
+++ b/.github/workflows/build_and_publish_to_test_pypi.yml
@@ -41,13 +41,18 @@ jobs:
   
       - name: 'Install MacPorts'
         if: runner.os == 'macOS'
-        uses: melusina-org/setup-macports@v1
-
-      - name: 'Install MacPorts Packages'
-        if: runner.os == 'macOS'
         run: |
-          port clean net-snmp openssl;
-          port install net-snmp openssl;
+          mkdir -p $HOME/opt/mports
+          cd $HOME/opt/mports
+          wget https://github.com/macports/macports-base/releases/download/v2.9.1/MacPorts-2.9.1.tar.gz
+          tar -xzvf MacPorts-2.9.1.tar.gz
+          cd $HOME/opt/mports/MacPorts-2.9.1
+          ./configure --prefix=$HOME/opt/local --with-install-user=`id -un` --with-install-group=`id -gn`
+          make
+          make install
+          make distclean
+          export PATH=$HOME/opt/local/bin:$HOME/opt/local/sbin:$PATH
+          port selfupdate
 
       - name: Install cibuildwheel
         run: |
@@ -58,7 +63,9 @@ jobs:
         with:
           linux: python -m cibuildwheel --output-dir wheelhouse --platform linux;
           
-          macos: python -m cibuildwheel --output-dir wheelhouse --platform macos;
+          macos: port clean net-snmp openssl;
+                 port install net-snmp openssl;
+                 python -m cibuildwheel --output-dir wheelhouse --platform macos;
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build_and_publish_to_test_pypi.yml
+++ b/.github/workflows/build_and_publish_to_test_pypi.yml
@@ -32,11 +32,16 @@ jobs:
     strategy:
       matrix:
         # os: [ubuntu-latest, macos-13, macos-14]
+        # macos-13 is an intel runner, macos-14 is apple silicon
         os: [macos-13, macos-14]
 
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
+  
+      - name: 'Install MacPorts'
+        if: runner.os == 'macOS'
+        uses: melusina-org/setup-macports@v1
 
       - name: Install cibuildwheel
         run: |
@@ -47,7 +52,8 @@ jobs:
         with:
           linux: python -m cibuildwheel --output-dir wheelhouse --platform linux;
           
-          macos: python -m cibuildwheel --output-dir wheelhouse --platform macos;
+          macos: port install net-snmp openssl;
+                 python -m cibuildwheel --output-dir wheelhouse --platform macos;
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build_and_publish_to_test_pypi.yml
+++ b/.github/workflows/build_and_publish_to_test_pypi.yml
@@ -42,6 +42,9 @@ jobs:
       - name: 'Install MacPorts'
         if: runner.os == 'macOS'
         uses: melusina-org/setup-macports@v1
+        run: |
+          port clean net-snmp openssl;
+          port install net-snmp openssl;
 
       - name: Install cibuildwheel
         run: |
@@ -52,9 +55,7 @@ jobs:
         with:
           linux: python -m cibuildwheel --output-dir wheelhouse --platform linux;
           
-          macos: port clean net-snmp openssl;
-                 port install net-snmp openssl;
-                 python -m cibuildwheel --output-dir wheelhouse --platform macos;
+          macos: python -m cibuildwheel --output-dir wheelhouse --platform macos;
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build_and_publish_to_test_pypi.yml
+++ b/.github/workflows/build_and_publish_to_test_pypi.yml
@@ -5,30 +5,30 @@ name: TestPyPI Distributions
 concurrency: build_and_publish_to_test_pypi
 on:
   push:
-    branches: [main]
+    branches: [167-investigate-arm64-builds-for-macos]
 
 jobs:
-  check-source-changes:
-    runs-on: ubuntu-latest
-    outputs:
-      run_job: ${{ steps.changed-files.outputs.any_changed }}
-    steps:
-      - name: Checkout Sourcecode
-        uses: actions/checkout@v4
+  # check-source-changes:
+  #   runs-on: ubuntu-latest
+  #   outputs:
+  #     run_job: ${{ steps.changed-files.outputs.any_changed }}
+  #   steps:
+  #     - name: Checkout Sourcecode
+  #       uses: actions/checkout@v4
 
-      - name: Check for changes in setup.py/cfg
-        id: changed-files
-        uses: tj-actions/changed-files@v45.0.0
-        with:
-          files: |
-            setup.py
-            setup.cfg
+  #     - name: Check for changes in setup.py/cfg
+  #       id: changed-files
+  #       uses: tj-actions/changed-files@v45.0.0
+  #       with:
+  #         files: |
+  #           setup.py
+  #           setup.cfg
 
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    needs: check-source-changes
-    if: needs.check-source-changes.outputs.run_job == 'true'
+    # needs: check-source-changes
+    # if: needs.check-source-changes.outputs.run_job == 'true'
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]

--- a/.github/workflows/build_and_publish_to_test_pypi.yml
+++ b/.github/workflows/build_and_publish_to_test_pypi.yml
@@ -52,7 +52,8 @@ jobs:
         with:
           linux: python -m cibuildwheel --output-dir wheelhouse --platform linux;
           
-          macos: port install net-snmp openssl;
+          macos: port clean net-snmp openssl;
+                 port install net-snmp openssl;
                  python -m cibuildwheel --output-dir wheelhouse --platform macos;
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/build_and_publish_to_test_pypi.yml
+++ b/.github/workflows/build_and_publish_to_test_pypi.yml
@@ -48,10 +48,7 @@ jobs:
         with:
           linux: python -m cibuildwheel --output-dir wheelhouse --platform linux;
           
-          macos: export PATH=$HOME/opt/local/bin:$HOME/opt/local/sbin:$PATH;
-                 port clean net-snmp openssl;
-                 port install net-snmp openssl;
-                 python -m cibuildwheel --output-dir wheelhouse --platform macos;
+          macos: python -m cibuildwheel --output-dir wheelhouse --platform macos;
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build_and_publish_to_test_pypi.yml
+++ b/.github/workflows/build_and_publish_to_test_pypi.yml
@@ -31,7 +31,8 @@ jobs:
     # if: needs.check-source-changes.outputs.run_job == 'true'
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        # os: [ubuntu-latest, macos-13, macos-14]
+        os: [macos-13, macos-14]
 
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ before-all = """brew update;
     export PATH="/usr/local/opt/net-snmp/bin:$PATH";
     echo 'export PATH="/usr/local/opt/net-snmp/sbin:$PATH"' >> ~/.zshrc;
     export PATH="/usr/local/opt/net-snmp/sbin:$PATH";"""
-archs = ["x86_64"]
 repair-wheel-command = "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}"
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ before-all = """brew update;
     export PATH="/usr/local/opt/net-snmp/bin:$PATH";
     echo 'export PATH="/usr/local/opt/net-snmp/sbin:$PATH"' >> ~/.zshrc;
     export PATH="/usr/local/opt/net-snmp/sbin:$PATH";"""
+archs = ["universal2"]
 repair-wheel-command = "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}"
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ before-all = """brew update;
     export PATH="/usr/local/opt/net-snmp/bin:$PATH";
     echo 'export PATH="/usr/local/opt/net-snmp/sbin:$PATH"' >> ~/.zshrc;
     export PATH="/usr/local/opt/net-snmp/sbin:$PATH";"""
-archs = ["arm64"]
 repair-wheel-command = "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}"
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,12 +5,12 @@ skip = "cp27-* cp36-* cp37-* pp27-* pp36-* pp37-*"
 [[tool.cibuildwheel.overrides]]
 select = "*manylinux_2_24*"
 before-all = """apt-get --assume-yes install wget unzip;
-                wget https://sourceforge.net/projects/net-snmp/files/net-snmp/5.9.4/net-snmp-5.9.4.zip/download ;
+                wget https://sourceforge.net/projects/net-snmp/files/net-snmp/5.9.4/net-snmp-5.9.4.zip/download;
                 unzip download;
                 cd net-snmp-5.9.4;
                 ./configure --with-defaults --disable-mibs --disable-manual --without-perl-modules --disable-embedded-perl;
-                make ;
-                make install ;"""
+                make;
+                make install;"""
 
 [[tool.cibuildwheel.overrides]]
 select = "*musllinux*"
@@ -26,13 +26,19 @@ before-all = """yum -y install wget;
                 make install ;"""
 
 [tool.cibuildwheel.macos]
-before-all = """brew update;
-    brew install openssl@3;
-    brew install net-snmp;
-    echo 'export PATH="/usr/local/opt/net-snmp/bin:$PATH"' >> ~/.zshrc;
-    export PATH="/usr/local/opt/net-snmp/bin:$PATH";
-    echo 'export PATH="/usr/local/opt/net-snmp/sbin:$PATH"' >> ~/.zshrc;
-    export PATH="/usr/local/opt/net-snmp/sbin:$PATH";"""
+before-all = """mkdir -p $HOME/opt/mports;
+          cd $HOME/opt/mports;
+          wget https://github.com/macports/macports-base/releases/download/v2.10.1/MacPorts-2.10.1.tar.gz;
+          tar -xzvf MacPorts-2.10.1.tar.gz;
+          cd $HOME/opt/mports/MacPorts-2.10.1;
+          ./configure --prefix=$HOME/opt/local --with-install-user=`id -un` --with-install-group=`id -gn`;
+          make;
+          make install;
+          make distclean;
+          export PATH=$HOME/opt/local/bin:$HOME/opt/local/sbin:$PATH;
+          port selfupdate;
+          port clean net-snmp openssl;
+          port install net-snmp openssl;"""
 repair-wheel-command = "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}"
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ before-all = """brew update;
     export PATH="/usr/local/opt/net-snmp/bin:$PATH";
     echo 'export PATH="/usr/local/opt/net-snmp/sbin:$PATH"' >> ~/.zshrc;
     export PATH="/usr/local/opt/net-snmp/sbin:$PATH";"""
-archs = ["universal2"]
+archs = ["arm64"]
 repair-wheel-command = "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}"
 
 [build-system]


### PR DESCRIPTION
- This re-enables support for arm builds on MacOS. We now build X86 and arm builds.
- Switched to using MacPorts. It is more reproducible than homebrew is.