### PR TITLE
Feature/Update Pyproject File For Linux Builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,30 +5,14 @@ skip = "cp27-* cp36-* cp37-* cp38-* pp*"
 
 [[tool.cibuildwheel.overrides]]
 select = "*manylinux_2_2*"
-before-all = """apt-get --assume-yes install wget unzip openssl libssl-dev;
-                wget https://sourceforge.net/projects/net-snmp/files/net-snmp/5.9.4/net-snmp-5.9.4.zip/download;
-                unzip download;
-                cd net-snmp-5.9.4;
-                ./configure --with-defaults --disable-mibs  --disable-manual --without-perl-modules --disable-embedded-perl;
-                make -j$(nproc);
-                make install;
-                echo "/usr/local/lib" >> /etc/ld.so.conf.d/net-snmp.conf;
-                ldconfig;"""
+before-all = """apt-get --assume-yes update; apt-get --assume-yes install net-snmp net-snmp-dev openssl libssl-dev;"""
 
 [[tool.cibuildwheel.overrides]]
 select = "*musllinux*"
 before-all = "apk add net-snmp-dev openssl openssl-dev;"
 
 [tool.cibuildwheel.linux]
-before-all = """yum -y install wget openssl openssl-devel;
-                wget https://sourceforge.net/projects/net-snmp/files/net-snmp/5.9.4/net-snmp-5.9.4.zip/download ;
-                unzip download;
-                cd net-snmp-5.9.4;
-                ./configure --with-defaults --disable-mibs  --disable-manual --without-perl-modules --disable-embedded-perl;
-                make -j$(nproc);
-                make install;
-                echo "/usr/local/lib" >> /etc/ld.so.conf.d/net-snmp.conf;
-                ldconfig;"""
+before-all = """yum -y update; yum -y install net-snmp net-snmp-devel openssl openssl-devel;"""
 repair-wheel-command = "auditwheel repair -w {dest_dir} {wheel}"
 
 [tool.cibuildwheel.macos]
@@ -56,7 +40,7 @@ repair-wheel-command = "delocate-wheel --require-archs {delocate_archs} -w {dest
 [build-system]
 build-backend = "setuptools.build_meta"
 requires = [
-   "setuptools == 80.3.1",
+    "setuptools == 80.3.1",
     "wheel == 0.46.1",
 ]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,16 @@ keywords =
     easysnmp
     snmp
     pysnmp
+    python snmp
+    snmp library
+    snmp client
+    snmp agent
+    snmp manager
+    snmp monitoring
+    network monitoring
+    network management
+    mib
+    network scripting
 platforms =
     Linux 32/64
     MacOS 32/64

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ezsnmp
-version = 2.1.0a0
+version = 2.1.0a1
 description = A blazingly fast and Pythonic SNMP library based on the official Net-SNMP bindings. We use SWIG to generate the wrapper code for us.
 author = Carlos Santos
 author_email = dose.lucky.sake@cloak.id

--- a/sphinx_docs_build/source/conf.py
+++ b/sphinx_docs_build/source/conf.py
@@ -24,7 +24,7 @@ copyright = "2024-%Y, carlkidcrypto"
 author = "carlkidcrypto"
 
 # The full version, including alpha/beta/rc tags
-release = "v2.1.0a0"
+release = "v2.1.0a1"
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
This change ensures that cibuildwheel builds utilize the local net-snmp version, rather than version 5.9, which should help resolve installation issues.