### PR TITLE
Update Sphinx build workflow to run apt update

### DIFF
--- a/.github/workflows/sphinx_build.yml
+++ b/.github/workflows/sphinx_build.yml
@@ -40,6 +40,7 @@ jobs:
         uses: carlkidcrypto/os-specific-runner@39336e3ec1a53bcdce44b9e9388da204f79203d9 # v2.1.3
         with:
           linux: |
+            sudo apt update;
             sudo apt install -y libsnmp-dev g++ python3-dev doxygen;
 
       - name: Install Pip Requirements


### PR DESCRIPTION
Added 'sudo apt update' before installing dependencies in the Sphinx build GitHub Actions workflow to ensure package lists are up to date.