### PR TITLE
Release Prep

### DIFF
--- a/docker/cache/download_build_cache.sh
+++ b/docker/cache/download_build_cache.sh
@@ -29,7 +29,6 @@ SQLITE_URL="https://www.sqlite.org/2024/sqlite-autoconf-${SQLITE_VERSION}.tar.gz
 
 # Net-SNMP versions
 NETSNMP_VERSIONS=(
-    "5.6.2.1:https://sourceforge.net/projects/net-snmp/files/net-snmp/5.6.2.1/net-snmp-5.6.2.1.tar.gz"
     "5.7.3:https://sourceforge.net/projects/net-snmp/files/net-snmp/5.7.3/net-snmp-5.7.3.tar.gz"
     "5.8:https://sourceforge.net/projects/net-snmp/files/net-snmp/5.8/net-snmp-5.8.tar.gz"
     "5.9.5.2:https://sourceforge.net/projects/net-snmp/files/net-snmp/5.9.5.2/net-snmp-5.9.5.2.tar.gz"
@@ -94,7 +93,7 @@ download() {
 # Order:
 # 1) exact tag v<version>
 # 2) exact tag with common patch suffixes (v<version>.1, v<version>.2)
-# 3) nearest stable tag in same major.minor line (e.g. v5.6.2.1 for 5.6.x)
+# 3) nearest stable tag in same major.minor line (e.g. v5.7.3-1 for 5.7.x)
 resolve_netsnmp_github_tag() {
     local requested_version="$1"
     local major_minor

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ezsnmp
-version = 2.4.0a9
+version = 2.4.0b0
 description = A blazingly fast and Pythonic SNMP library based on the official Net-SNMP bindings. We use SWIG to generate the wrapper code for us.
 author = Carlos Santos
 author_email = 27721404+carlkidcrypto@users.noreply.github.com

--- a/sphinx_docs_build/source/conf.py
+++ b/sphinx_docs_build/source/conf.py
@@ -24,7 +24,7 @@ copyright = "2024-%Y, carlkidcrypto"
 author = "carlkidcrypto"
 
 # The full version, including alpha/beta/rc tags
-release = "v2.4.0a9"
+release = "v2.4.0b0"
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
Remove legacy net-snmp 5.6
Bump to first beta release. Nearing next stable release.