### PR TITLE
[docs-improvement] Fix method name reference and broken line-continuation in docs

### DIFF
--- a/HOWTOAI.rst
+++ b/HOWTOAI.rst
@@ -354,7 +354,7 @@ Example 3: Adding a New Session Method
 
     Prompt: "I want to add a 'get_bulk_repeaters' method to ezsnmp Session class 
     that allows specifying different max-repetitions for different OIDs. 
-    Based on the existing get() and bulkwalk() patterns, draft:
+    Based on the existing get() and bulk_walk() patterns, draft:
     1. The Python Session method in session.py
     2. The C++ SessionBase method in src/sessionbase.cpp
     3. The SWIG interface declaration in interface/sessionbase.i"

--- a/ezsnmp/README.rst
+++ b/ezsnmp/README.rst
@@ -81,8 +81,8 @@ for the C++ code. To regenerate the SWIG wrappers:
 
 .. code-block:: bash
 
-    swig -c++ -python -builtin -threads -doxygen -std=c++17 \\
-         -outdir ezsnmp/. -o ezsnmp/src/ezsnmp_netsnmpbase.cpp \\
+    swig -c++ -python -builtin -threads -doxygen -std=c++17 \
+         -outdir ezsnmp/. -o ezsnmp/src/ezsnmp_netsnmpbase.cpp \
          ezsnmp/interface/netsnmpbase.i
 
 For complete SWIG build commands, see the `Development Guide <../sphinx_docs_build/source/development.rst>`_.


### PR DESCRIPTION
- HOWTOAI.rst: corrected 'bulkwalk()' reference to actual method name 'bulk_walk()'
- ezsnmp/README.rst: fixed doubled backslashes (\\) in bash code block that would break line continuation if copy-pasted

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
